### PR TITLE
Use random high port number between 2000 and 65000

### DIFF
--- a/proxy
+++ b/proxy
@@ -1,7 +1,7 @@
 # !/bin/sh
 # SSH SOCKS proxy script for Mac OS X
 
-localport=$RANDOM
+localport=`jot -r 1 2000 65000`
 remoteuser="SSH_USER_HERE"
 remoteproxy="IP_OR_HOSTNAME_HERE"
 remoteport="22"


### PR DESCRIPTION
`$RANDOM` generates an integer in the range 0 - 32767, which might 
produce an integer smaller than 1024, which might coincide with a [well known port](http://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers#Well-known_ports).

Using `jot -r 1 2000 65000` produces a port number that should be safer to use.
