### PR TITLE
Adds ability to use either Ethernet or Wi-Fi

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,13 @@ remoteport="22"
 Run like this:
 
 ```
-proxy [on|off|killall|shutdown|no_argument]
+proxy [on|off|killall|shutdown|no_argument] [Wi-Fi|Ethernet]
 
 on = turn proxy on and setup ssh tunnel
 off = turn proxy off
 killall = kill all ssh tunnels
 shutdown = off and killall
 no_arg = toggle current state (if on, set as off, if off set as on)
+
+Wi-Fi | Ethernet = sets the interface to proxy (optional: defaults to Wi-Fi)
 ```

--- a/proxy
+++ b/proxy
@@ -18,7 +18,7 @@
 remoteuser=$PROXY_USER
 remoteproxy=$PROXY_HOST
 remoteport="22"
-
+#
 # Get the min and max system-available ports.
 lowerport=`sysctl net.inet.ip.portrange.first | cut -d " " -f 2`
 upperport=`sysctl net.inet.ip.portrange.last | cut -d " " -f 2`
@@ -27,7 +27,7 @@ localport=`jot -r 1 $lowerport $upperport`
 
 usage(){
 echo ""
-echo "Usage: proxy [on|off|killall|shutdown|no_args]"
+echo "Usage: proxy [on|off|killall|shutdown|no_args] [Wi-Fi|Ethernet]"
 echo "Proxy is a proxy settings toggle script for OSX"
 echo "Proxy initiates an SSH tunnel and then enables a Socks proxy"
 }
@@ -37,20 +37,28 @@ echo "Unknown input, try again with different term"
 }
 
 get_proxy_state(){
-  result=`networksetup -getsocksfirewallproxy Wi-Fi | head -1 | cut -d ' ' -f2`
+  result=`networksetup -getsocksfirewallproxy $interface | head -1 | cut -d ' ' -f2`
   echo $result
+}
+
+set_interface(){
+  if [[ $2 =~ "^[Ee]th" ]]; then
+    interface="Ethernet"
+  else
+    interface="Wi-Fi"
+  fi
 }
 
 proxy_on(){
   echo "Listening on localhost:$localport. Modifying network settings.."
-  sudo networksetup -setsocksfirewallproxy Wi-Fi 127.0.0.1 $localport off
+  sudo networksetup -setsocksfirewallproxy $interface 127.0.0.1 $localport off
   echo "Starting SSH session. Will run in background for 1 day."
   ssh -f -p $remoteport -D $localport $remoteuser@$remoteproxy sleep 1d
 }
 
 proxy_off(){
   echo "Disabling proxy in network settings."
-  sudo networksetup -setsocksfirewallproxystate Wi-Fi off
+  sudo networksetup -setsocksfirewallproxystate $interface off
   echo "Done!"
 }
 
@@ -80,6 +88,8 @@ toggle_state(){
     echo "ON"
   fi
 }
+
+set_interface
 
 case $1 in
 "on")


### PR DESCRIPTION
Accomplished by using $2 variable from commandline.

Resolves most of [Issue #1](https://github.com/12k/osx-proxy/issues/1) except the automatically knowing which interface to use with `proxy off`.
